### PR TITLE
Update GAU Allocations report

### DIFF
--- a/src/reports/NPSP_Fundraising_Reports/GAU_Allocations_Payments.report
+++ b/src/reports/NPSP_Fundraising_Reports/GAU_Allocations_Payments.report
@@ -90,7 +90,7 @@
         <blockId xsi:nil="true"/>
         <joinTable>fko</joinTable>
     </blockInfo>
-    <description>Joined report (Classic Only) that provides GAU Allocation and Payment information in a single view, grouped by Opportunity.</description>
+    <description>Joined report that provides GAU Allocation and Payment information in a single view, grouped by Opportunity.</description>
     <format>MultiBlock</format>
     <groupingsDown>
         <dateGranularity>Day</dateGranularity>


### PR DESCRIPTION
Update description to remove that it's Classic Only now that Lightning supports joined reports.